### PR TITLE
Filter scanned items by source in cache retrieval

### DIFF
--- a/app/Http/Controllers/v1/Store/StoreReceivingInventoryItemCacheController.php
+++ b/app/Http/Controllers/v1/Store/StoreReceivingInventoryItemCacheController.php
@@ -40,14 +40,15 @@ class StoreReceivingInventoryItemCacheController extends Controller
             $storeReceivingInventoryItemCacheModel = StoreReceivingInventoryItemCacheModel::where([
                 'reference_number' => $reference_number,
                 'receive_type' => $receive_type
-            ])->orderBy('id','DESC')->first();
+            ])->orderBy('id', 'DESC')->first();
 
             if ($storeReceivingInventoryItemCacheModel) {
                 $decodedItems = json_decode($storeReceivingInventoryItemCacheModel->scanned_items, true);
 
-                $itemCodes = json_decode($selected_item_codes, true); 
+                $itemCodes = json_decode($selected_item_codes, true);
+
                 $filteredItems = array_values(array_filter($decodedItems, function ($item) use ($itemCodes) {
-                    return in_array($item['ic'], $itemCodes);
+                    return in_array($item['ic'], $itemCodes) && strtolower($item['source']) === 'new';
                 }));
 
                 $storeReceivingInventoryItemCacheModel->scanned_items = $filteredItems;


### PR DESCRIPTION
Updated the onGetCurrent method to filter scanned items by both item code and ensure the item's source is 'new' (case-insensitive) when retrieving from the cache. This ensures only newly sourced items are included in the response.