### PR TITLE
Update item filtering logic in inventory cache controller

### DIFF
--- a/app/Http/Controllers/v1/Store/StoreReceivingInventoryItemCacheController.php
+++ b/app/Http/Controllers/v1/Store/StoreReceivingInventoryItemCacheController.php
@@ -47,8 +47,8 @@ class StoreReceivingInventoryItemCacheController extends Controller
 
                 $itemCodes = json_decode($selected_item_codes, true);
 
-                $filteredItems = array_values(array_filter($decodedItems, function ($item) use ($itemCodes) {
-                    return in_array($item['ic'], $itemCodes) && strtolower($item['source']) === 'new';
+                $filteredItems = array_values(array_filter($decodedItems, function ($item) use ($itemCodes) { // Return items that are selected from the store receiving and also return the new or wrong dropped items
+                    return in_array($item['ic'], $itemCodes) || strtolower($item['source']) === 'new';
                 }));
 
                 $storeReceivingInventoryItemCacheModel->scanned_items = $filteredItems;


### PR DESCRIPTION
Modified the filter to include items that are either selected or have a source of 'new', instead of requiring both conditions. This ensures that both selected items and new or incorrectly dropped items are returned.