### PR TITLE
Add filtering to StockOut get endpoint by store

### DIFF
--- a/app/Http/Controllers/v1/Stock/StockOutController.php
+++ b/app/Http/Controllers/v1/Stock/StockOutController.php
@@ -56,12 +56,20 @@ class StockOutController extends Controller
         }
     }
 
-    public function onGet()
+    public function onGet($storeCode, $storeSubUnitShortName = null)
     {
         $orderFields = [
             'key' => 'id',
             'value' => 'DESC'
         ];
-        return $this->readRecord(StockOutModel::class, 'stock_outs', null, $orderFields);
+
+        $whereFields = [
+            'store_code' => $storeCode,
+        ];
+
+        if ($storeSubUnitShortName) {
+            $whereFields['store_sub_unit_short_name'] = $storeSubUnitShortName;
+        }
+        return $this->readCurrentRecord(StockOutModel::class, null, $whereFields, null, $orderFields, 'Stock Out');
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -152,7 +152,7 @@ Route::group(['middleware' => ['auth:sanctum', 'check.system.status:SIS']], func
 
     #region Stock Out
     Route::post('v1/stock/out/create', [App\Http\Controllers\v1\Stock\StockOutController::class, 'onCreate']);
-    Route::get('v1/stock/out/get', [App\Http\Controllers\v1\Stock\StockOutController::class, 'onGet']);
+    Route::get('v1/stock/out/get/{store_code}/{store_sub_unit_short_name?}', [App\Http\Controllers\v1\Stock\StockOutController::class, 'onGet']);
     #endregion
 
     #region Stock Out Item


### PR DESCRIPTION
Updated the StockOutController onGet method to accept store code and optional store sub unit short name as parameters, enabling filtering of stock out records by these fields. Modified the API route to include these parameters in the URL.