### PR TITLE
Include 'id' field in report data responses

### DIFF
--- a/app/Http/Controllers/v1/Report/StockConversionReportController.php
+++ b/app/Http/Controllers/v1/Report/StockConversionReportController.php
@@ -40,6 +40,7 @@ class StockConversionReportController extends Controller
 
                 $item->stockConversionItems->each(function ($conversionItem) use (&$reportData, $item) {
                     $reportData[] = [
+                        'id' => $item->id,
                         'reference_number' => $item['reference_number'],
                         'store_code' => $item['store_code'],
                         'store_name' => $item['formatted_store_name_label'],

--- a/app/Http/Controllers/v1/Report/StockOutReportController.php
+++ b/app/Http/Controllers/v1/Report/StockOutReportController.php
@@ -40,6 +40,7 @@ class StockOutReportController extends Controller
 
                 $item->stockOutItems->each(function ($outItem) use (&$reportData, $item) {
                     $reportData[] = [
+                        'id' => $item->id,
                         'reference_number' => $item['reference_number'],
                         'store_code' => $item['store_code'],
                         'store_name' => $item['formatted_store_name_label'],

--- a/app/Http/Controllers/v1/Report/StockTransferReportController.php
+++ b/app/Http/Controllers/v1/Report/StockTransferReportController.php
@@ -59,6 +59,7 @@ class StockTransferReportController extends Controller
             foreach ($stockTransferModel as $item) {
                 $item->stockTransferItems->each(function ($transferItem) use (&$reportData, $item) {
                     $reportData[] = [
+                        'id' => $item->id,
                         'reference_number' => $item['reference_number'],
                         'transferred_by' => $item['created_by_name_label'] ?? null,
                         'date_created' => $item['formatted_created_at_label'] ?? null,

--- a/app/Http/Controllers/v1/Report/StoreInventoryReportController.php
+++ b/app/Http/Controllers/v1/Report/StoreInventoryReportController.php
@@ -25,6 +25,7 @@ class StoreInventoryReportController extends Controller
             $isReceived = $request->is_received ?? null; // Expected values: 0 (Pending), 1 (Received) For store receiving
 
             $storeInventoryModel = StockInventoryModel::select([
+                'id',
                 'store_code',
                 'store_sub_unit_short_name',
                 'item_code',
@@ -70,6 +71,7 @@ class StoreInventoryReportController extends Controller
                 $t1 = $beginningStock + $firstDelivery + $secondDelivery + $thirdDelivery;
                 $actualCount = StockLogModel::onGetActualStock($transactionDate, $itemCode, $storeCode, $storeSubUnitShortName);
                 $reportData["$itemCode|$storeCode|$storeSubUnitShortName"] = [
+                    'id' => $inventory->id,
                     'store_code' => $storeCode,
                     'store_sub_unit_short_name' => $storeSubUnitShortName,
                     'item_code' => $itemCode,

--- a/app/Http/Controllers/v1/Report/StoreReceivingReportController.php
+++ b/app/Http/Controllers/v1/Report/StoreReceivingReportController.php
@@ -23,6 +23,7 @@ class StoreReceivingReportController extends Controller
             $status = $request->status ?? null; // Expected values: 0 (Pending), 1 (Complete)
 
             $storeReceivingInventoryItems = StoreReceivingInventoryItemModel::select([
+                'id',
                 'store_code',
                 'store_name',
                 'store_sub_unit_short_name',
@@ -86,6 +87,7 @@ class StoreReceivingReportController extends Controller
                 }
 
                 $reportData[] = [
+                    'id' => $item['id'],
                     'dr_no' => $orderSessionId,
                     'delivery_date' => $deliveryDate,
                     'store_code' => $storeCode,


### PR DESCRIPTION
Added the 'id' field to report data arrays and select queries in StockConversionReportController, StockOutReportController, StockTransferReportController, StoreInventoryReportController, and StoreReceivingReportController. This change ensures that the unique identifier for each record is available in the generated report data.