### PR TITLE
Fix report item ID assignment in daily reports

### DIFF
--- a/app/Http/Controllers/v1/Report/StockConversionReportController.php
+++ b/app/Http/Controllers/v1/Report/StockConversionReportController.php
@@ -40,7 +40,7 @@ class StockConversionReportController extends Controller
 
                 $item->stockConversionItems->each(function ($conversionItem) use (&$reportData, $item) {
                     $reportData[] = [
-                        'id' => $item->id,
+                        'id' => $conversionItem->id,
                         'reference_number' => $item['reference_number'],
                         'store_code' => $item['store_code'],
                         'store_name' => $item['formatted_store_name_label'],

--- a/app/Http/Controllers/v1/Report/StockOutReportController.php
+++ b/app/Http/Controllers/v1/Report/StockOutReportController.php
@@ -40,7 +40,7 @@ class StockOutReportController extends Controller
 
                 $item->stockOutItems->each(function ($outItem) use (&$reportData, $item) {
                     $reportData[] = [
-                        'id' => $item->id,
+                        'id' => $outItem->id,
                         'reference_number' => $item['reference_number'],
                         'store_code' => $item['store_code'],
                         'store_name' => $item['formatted_store_name_label'],

--- a/app/Http/Controllers/v1/Report/StockTransferReportController.php
+++ b/app/Http/Controllers/v1/Report/StockTransferReportController.php
@@ -59,7 +59,7 @@ class StockTransferReportController extends Controller
             foreach ($stockTransferModel as $item) {
                 $item->stockTransferItems->each(function ($transferItem) use (&$reportData, $item) {
                     $reportData[] = [
-                        'id' => $item->id,
+                        'id' => $transferItem->id,
                         'reference_number' => $item['reference_number'],
                         'transferred_by' => $item['created_by_name_label'] ?? null,
                         'date_created' => $item['formatted_created_at_label'] ?? null,


### PR DESCRIPTION
Corrects the 'id' field in daily report data for stock conversion, stock out, and stock transfer reports to use the item's child record ID instead of the parent record ID. This ensures each report entry references the correct item.