### PR TITLE
Fix date_created field in daily stock transfer report

### DIFF
--- a/app/Http/Controllers/v1/Report/StockTransferReportController.php
+++ b/app/Http/Controllers/v1/Report/StockTransferReportController.php
@@ -91,7 +91,7 @@ class StockTransferReportController extends Controller
                         'id' => $transferItem->id,
                         'reference_number' => $item['reference_number'],
                         'transferred_by' => $item['created_by_name_label'] ?? null,
-                        'date_created' => $item['formatted_created_at_label'] ?? null,
+                        'date_created' => $item['formatted_created_at_report_label'] ?? null,
                         'scheduled_pickup_date' => $item['pickup_date'],
                         'actual_pickup_date' => $item['formatted_logistics_picked_up_at_report_label'] ?? null,
                         'transport_type' => $item['transportation_type_label'] ?? null,


### PR DESCRIPTION
Updated the 'date_created' field to use 'formatted_created_at_report_label' instead of 'formatted_created_at_label' for more accurate report formatting in the daily stock transfer report generation.