### PR TITLE
Make onGetActualCountEOD method static

### DIFF
--- a/app/Models/Stock/StockInventoryCountModel.php
+++ b/app/Models/Stock/StockInventoryCountModel.php
@@ -139,7 +139,7 @@ class StockInventoryCountModel extends Model
         return null;
     }
 
-    public function onGetActualCountEOD($transactionDate, $itemCode, $storeCode, $storeSubUnitShortName)
+    public static function onGetActualCountEOD($transactionDate, $itemCode, $storeCode, $storeSubUnitShortName)
     {
         try {
             $stockInventoryCountModel = self::where([


### PR DESCRIPTION
Changed the onGetActualCountEOD method from an instance method to a static method in StockInventoryCountModel. This allows the method to be called statically without requiring an instance of the model.