### PR TITLE
Update StockTransferController.php

### DIFF
--- a/app/Http/Controllers/v1/Stock/StockTransferController.php
+++ b/app/Http/Controllers/v1/Stock/StockTransferController.php
@@ -60,7 +60,7 @@ class StockTransferController extends Controller
                 'store_code' => $storeCode,
                 'store_sub_unit_short_name' => $storeSubUnitShortName,
                 'transfer_type' => $transferTypeArr[$type],
-                'transportation_type' => $transportationType,
+                'transportation_type' => $type == 1 ? 1 : $transportationType,
                 'pickup_date' => $pickupDate,
                 'location_code' => $transferToStoreCode,
                 'location_name' => $transferToStoreName,


### PR DESCRIPTION
This pull request makes a targeted change to the stock transfer creation logic, specifically affecting how the `transportation_type` field is set in the transfer data.

- Business logic update:
  * In the `onCreate` method of `StockTransferController.php`, the assignment of the `transportation_type` field now sets it to `1` if the `$type` variable equals `1`; otherwise, it uses the original `$transportationType` value. This change likely enforces a specific transportation type for certain transfer types.