### PR TITLE
Add formatted_store_name_label to StockInventoryModel

### DIFF
--- a/app/Http/Controllers/v1/Report/StoreInventoryReportController.php
+++ b/app/Http/Controllers/v1/Report/StoreInventoryReportController.php
@@ -37,7 +37,6 @@ class StoreInventoryReportController extends Controller
             $storeInventoryModel = StockInventoryModel::select([
                 'id',
                 'store_code',
-                'store_name',
                 'store_sub_unit_short_name',
                 'item_code',
                 'item_description',
@@ -58,7 +57,6 @@ class StoreInventoryReportController extends Controller
             foreach ($storeInventoryModel as $inventory) {
                 $itemCode = $inventory->item_code;
                 $storeCode = $inventory->store_code;
-                $storeName = $inventory->store_name;
                 $storeSubUnitShortName = $inventory->store_sub_unit_short_name ?? null;
                 $beginningStock = StockLogModel::onGetBeginningStock($transactionDate, $itemCode, $storeCode, $storeSubUnitShortName);
 
@@ -87,7 +85,7 @@ class StoreInventoryReportController extends Controller
                 $reportData["$itemCode|$storeCode|$storeSubUnitShortName"] = [
                     'id' => $inventory->id,
                     'store_code' => $storeCode,
-                    'store_name' => $storeName,
+                    'store_name' => $inventory->formatted_store_name_label,
                     'store_sub_unit_short_name' => $storeSubUnitShortName,
                     'item_code' => $itemCode,
                     'item_description' => $inventory->item_description,

--- a/app/Models/Stock/StockInventoryModel.php
+++ b/app/Models/Stock/StockInventoryModel.php
@@ -2,6 +2,7 @@
 
 namespace App\Models\Stock;
 
+use App\Models\Store\StoreReceivingInventoryItemModel;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 class StockInventoryModel extends Model
@@ -10,6 +11,9 @@ class StockInventoryModel extends Model
 
     protected $table = 'stock_inventories';
 
+    protected $appends = [
+        'formatted_store_name_label',
+    ];
     protected $fillable = [
         'store_code',
         'store_sub_unit_short_name',
@@ -22,4 +26,11 @@ class StockInventoryModel extends Model
         'updated_by_id',
     ];
 
+    public function getFormattedStoreNameLabelAttribute()
+    {
+        $storeReceivingInventoryModel = StoreReceivingInventoryItemModel::select('store_name')->where('store_code', $this->store_code)
+            ->orderBy('id', 'DESC')
+            ->first();
+        return $storeReceivingInventoryModel ? $storeReceivingInventoryModel->store_name : null;
+    }
 }


### PR DESCRIPTION
Introduces the formatted_store_name_label accessor to StockInventoryModel, retrieving the latest store_name from StoreReceivingInventoryItemModel based on store_code. Updates StoreInventoryReportController to use this accessor instead of the direct store_name field.