### PR TITLE
Remove discrepancy filter from item count query

### DIFF
--- a/app/Http/Controllers/v1/Stock/StockInventoryItemCountController.php
+++ b/app/Http/Controllers/v1/Stock/StockInventoryItemCountController.php
@@ -105,7 +105,7 @@ class StockInventoryItemCountController extends Controller
             }
             $stockInventoryItemCountModel = StockInventoryItemCountModel::where([
                 'stock_inventory_count_id' => $store_inventory_count_id,
-            ])->where('discrepancy_quantity', '!=', 0)->get();
+            ])->get();
 
             foreach ($stockInventoryItemCountModel as $item) {
                 $stockInventoryCountData = json_decode($fields['stock_inventory_item_count_data'] ?? '[]', true);


### PR DESCRIPTION
The query for StockInventoryItemCountModel no longer filters by 'discrepancy_quantity != 0', now returning all items for the given stock_inventory_count_id. This change may affect logic that previously only processed items with discrepancies.