### PR TITLE
Refactor stock inventory count retrieval logic

### DIFF
--- a/app/Http/Controllers/v1/Stock/StockInventoryCountController.php
+++ b/app/Http/Controllers/v1/Stock/StockInventoryCountController.php
@@ -35,7 +35,7 @@ class StockInventoryCountController extends Controller
             ])->whereIn('status', [0, 1])->exists();
 
             if ($hasPending) {
-                return $this->dataResponse('success', 400, 'Still has pending stock count');
+                return $this->dataResponse('error', 400, 'Still has pending stock count');
             }
             $referenceNumber = StockInventoryCountModel::onGenerateReferenceNumber();
             $type = $fields['type'];
@@ -456,30 +456,15 @@ class StockInventoryCountController extends Controller
     public function onGet($status, $store_code, $sub_unit = null)
     {
         try {
-            $whereFields = [
-                'status' => $status,
-                'store_code' => $store_code,
-            ];
+            $stockInventoryCountModel = StockInventoryCountModel::where('store_code', $store_code);
+            if ($status == 0) {
+                $stockInventoryCountModel->whereIn('status', [0, 1]);
+            }
             if ($sub_unit) {
-                $whereFields['store_sub_unit_short_name'] = $sub_unit;
+                $stockInventoryCountModel->where('store_sub_unit_short_name', $sub_unit);
             }
-
-            $orderFields = [
-                'id' => 'DESC',
-            ];
-            $array = $this->readCurrentRecord(StockInventoryCountModel::class, null, $whereFields, null, $orderFields, 'Stock Inventory Count', false, null, null);
-
-            if (!isset($array->getOriginalContent()['success'])) {
-                return $this->dataResponse('error', 200, __('msg.record_not_found'));
-            }
-            $formatted = collect($array->getOriginalContent()['success']['data']->toArray())->map(function ($item) {
-                if (isset($item['created_at'])) {
-                    $item['created_at'] = Carbon::parse($item['created_at'])->format('Y-m-d H:i:s');
-                    $item['updated_at'] = Carbon::parse($item['created_at'])->format('Y-m-d H:i:s');
-                }
-                return $item;
-            })->toArray();
-            return $this->dataResponse('success', 200, __('msg.record_found'), $formatted);
+            $stockInventoryCountModel = $stockInventoryCountModel->orderBy('id', 'DESC')->get();
+            return $this->dataResponse('success', 200, __('msg.record_found'), $stockInventoryCountModel);
         } catch (Exception $exception) {
             return $this->dataResponse('error', 400, __('msg.record_not_found'), $exception->getMessage());
         }


### PR DESCRIPTION
Updated the onGet method to simplify query building and result formatting for stock inventory counts. Also corrected the response type from 'success' to 'error' when pending stock count exists in onCreate.