### PR TITLE
Enable pending stock count middleware in API routes

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -75,7 +75,7 @@ Route::group(['middleware' => ['auth:sanctum']], function () {
     Route::post('v1/store/cache', [App\Http\Controllers\v1\Auth\CredentialController::class, 'onStoreCache']);
 });
 
-Route::group(['middleware' => ['auth:sanctum', 'check.system.status:SIS', /*'check.pending.stock.count'*/]], function () {
+Route::group(['middleware' => ['auth:sanctum', 'check.system.status:SIS', 'check.pending.stock.count']], function () {
     #region Store Receiving Inventory
     Route::get('v1/store/receive-inventory/current/get/{status}/{store_code?}', [App\Http\Controllers\v1\Store\StoreReceivingInventoryController::class, 'onGetCurrent']);
     Route::get('v1/store/receive-inventory/get/{store_receiving_inventory_id}', [App\Http\Controllers\v1\Store\StoreReceivingInventoryController::class, 'onGetById']);


### PR DESCRIPTION
Uncomments the 'check.pending.stock.count' middleware in the protected API route group to ensure pending stock count checks are enforced for relevant endpoints.