### PR TITLE
Minor bug fix in store receiving cache

### DIFF
--- a/app/Http/Controllers/v1/Store/StoreReceivingInventoryItemCacheController.php
+++ b/app/Http/Controllers/v1/Store/StoreReceivingInventoryItemCacheController.php
@@ -36,7 +36,12 @@ class StoreReceivingInventoryItemCacheController extends Controller
     public function onGetCurrent($reference_number, $receive_type, $selected_item_codes)
     {
         try {
-            $selected_item_codes = str_replace(":", "", $selected_item_codes);
+            $decodedItemCodes = json_decode($selected_item_codes, true);
+            $itemCodes = array_map(function ($code) {
+                // split at ":" and take only the first part
+                return explode(":", $code)[0];
+            }, $decodedItemCodes);
+
             $storeReceivingInventoryItemCacheModel = StoreReceivingInventoryItemCacheModel::where([
                 'reference_number' => $reference_number,
                 'receive_type' => $receive_type
@@ -44,7 +49,6 @@ class StoreReceivingInventoryItemCacheController extends Controller
 
             if ($storeReceivingInventoryItemCacheModel) {
                 $decodedItems = json_decode($storeReceivingInventoryItemCacheModel->scanned_items, true);
-                $itemCodes = json_decode($selected_item_codes, true);
 
                 $filteredItems = array_values(array_filter($decodedItems, function ($item) use ($itemCodes) { // Return items that are selected from the store receiving and also return the new or wrong dropped items
                     return in_array($item['ic'], $itemCodes) || strtolower($item['source']) === 'new';

--- a/app/Http/Controllers/v1/Store/StoreReceivingInventoryItemController.php
+++ b/app/Http/Controllers/v1/Store/StoreReceivingInventoryItemController.php
@@ -47,12 +47,13 @@ class StoreReceivingInventoryItemController extends Controller
                 $itemCode = trim($item->item_code);
                 $orderType = $item->order_type;
                 $fanOutCategory = $item->fan_out_category;
-                $uniqueKey = "$itemCode:$fanOutCategory";
+                $uniqueKey = "$itemCode>$fanOutCategory";
                 if ($item->is_received == 0) {
                     $isReceived = false;
-                } else {
-                    $uniqueKey .= "-$fanOutCategory";
                 }
+                // else {
+                //     $uniqueKey .= "-$fanOutCategory";
+                // }
 
                 if (count($data['reservation_request']) === 0) {
                     $data['reservation_request'] = [
@@ -157,13 +158,14 @@ class StoreReceivingInventoryItemController extends Controller
                 $itemCode = trim($item->item_code);
                 $orderType = $item->order_type;
                 $fanOutCategory = $item->fan_out_category;
-                $uniqueKey = "$itemCode:$fanOutCategory";
+                $uniqueKey = "$itemCode>$fanOutCategory";
 
                 if ($item->is_received == 0) {
                     $isReceived = false;
-                } else {
-                    $uniqueKey .= "-$fanOutCategory";
                 }
+                // else {
+                //     $uniqueKey .= "-$fanOutCategory";
+                // }
 
                 if (count($data['reservation_request']) === 0) {
                     $data['reservation_request'] = [

--- a/app/Http/Controllers/v1/Store/StoreReceivingInventoryItemController.php
+++ b/app/Http/Controllers/v1/Store/StoreReceivingInventoryItemController.php
@@ -47,13 +47,12 @@ class StoreReceivingInventoryItemController extends Controller
                 $itemCode = trim($item->item_code);
                 $orderType = $item->order_type;
                 $fanOutCategory = $item->fan_out_category;
-                $uniqueKey = "$itemCode>$fanOutCategory";
+                $uniqueKey = "$itemCode:$fanOutCategory";
                 if ($item->is_received == 0) {
                     $isReceived = false;
+                } else {
+                    $uniqueKey .= "-$fanOutCategory";
                 }
-                // else {
-                //     $uniqueKey .= "-$fanOutCategory";
-                // }
 
                 if (count($data['reservation_request']) === 0) {
                     $data['reservation_request'] = [
@@ -158,14 +157,13 @@ class StoreReceivingInventoryItemController extends Controller
                 $itemCode = trim($item->item_code);
                 $orderType = $item->order_type;
                 $fanOutCategory = $item->fan_out_category;
-                $uniqueKey = "$itemCode>$fanOutCategory";
+                $uniqueKey = "$itemCode:$fanOutCategory";
 
                 if ($item->is_received == 0) {
                     $isReceived = false;
+                } else {
+                    $uniqueKey .= "-$fanOutCategory";
                 }
-                // else {
-                //     $uniqueKey .= "-$fanOutCategory";
-                // }
 
                 if (count($data['reservation_request']) === 0) {
                     $data['reservation_request'] = [

--- a/app/Models/Store/StoreReceivingInventoryItemModel.php
+++ b/app/Models/Store/StoreReceivingInventoryItemModel.php
@@ -26,7 +26,7 @@ class StoreReceivingInventoryItemModel extends Model
         'store_receiving_inventory_id',
         'reference_number',
         'order_type',
-        'fan_out_category',
+        'fan_out_category', // 0 = pullout, 1 = fresh
         'is_wrong_drop',
         'store_code',
         'store_name',


### PR DESCRIPTION
This pull request updates the handling of selected item codes in the store receiving inventory flow and improves code clarity with an inline comment. The main change is to correctly extract item codes from potentially complex input formats, ensuring only the relevant part of each code is used for filtering. Additionally, a clarifying comment is added to the `fan_out_category` field in the model.

**Inventory item code processing:**

* In `StoreReceivingInventoryItemCacheController.php`, the logic for processing `selected_item_codes` in `onGetCurrent` now decodes the JSON array and extracts only the code before the colon for each item, ensuring accurate filtering of inventory items.

**Model documentation improvement:**

* In `StoreReceivingInventoryItemModel.php`, an inline comment is added to the `fan_out_category` field to clarify its possible values (`0 = pullout, 1 = fresh`).